### PR TITLE
Dsm 3980 cant access environment vars in sb6 decorator

### DIFF
--- a/html/storybook-v5/.storybook/config.js
+++ b/html/storybook-v5/.storybook/config.js
@@ -1,7 +1,7 @@
 import { configure, addDecorator, addParameters } from '@storybook/html';
 import { withA11y } from '@storybook/addon-a11y';
 import centered from '@storybook/addon-centered/html';
-import { initDsm } from '@invisionapp/dsm-storybook';
+import { initDsm, withDsm } from '@invisionapp/dsm-storybook';
 
 /**
  * To override @invisionapp/dsm-storybook custom options\theme you can use Storybook options parameter and theming
@@ -19,12 +19,16 @@ import { initDsm } from '@invisionapp/dsm-storybook';
 // }
 
 addParameters({
-  backgrounds: [{ name: 'DSM background', value: '#f8f8fa', default: true }, { name: 'dark', value: '#333' }]
+  backgrounds: [
+    { name: 'DSM background', value: '#f8f8fa', default: true },
+    { name: 'dark', value: '#333' }
+  ]
 });
 
 addParameters({ docs: { page: null } });
 addDecorator(withA11y);
 addDecorator(centered);
+addDecorator(withDsm);
 
 //Init Dsm
 initDsm({

--- a/html/storybook-v5/.storybook/config.js
+++ b/html/storybook-v5/.storybook/config.js
@@ -1,7 +1,7 @@
 import { configure, addDecorator, addParameters } from '@storybook/html';
 import { withA11y } from '@storybook/addon-a11y';
 import centered from '@storybook/addon-centered/html';
-import { initDsm, withDsm } from '@invisionapp/dsm-storybook';
+import { initDsm } from '@invisionapp/dsm-storybook';
 
 /**
  * To override @invisionapp/dsm-storybook custom options\theme you can use Storybook options parameter and theming
@@ -28,7 +28,6 @@ addParameters({
 addParameters({ docs: { page: null } });
 addDecorator(withA11y);
 addDecorator(centered);
-addDecorator(withDsm);
 
 //Init Dsm
 initDsm({

--- a/html/storybook-v6/.storybook/preview.js
+++ b/html/storybook-v6/.storybook/preview.js
@@ -1,7 +1,7 @@
-import { withDsm } from '@invisionapp/dsm-storybook';
+import { withDsmHtml } from '@invisionapp/dsm-storybook';
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' }
 };
 
-export const decorators = [withDsm];
+export const decorators = [withDsmHtml];


### PR DESCRIPTION
## Description
Updated HTML examples with the correct DSM decorators. Storybook 6 changed some internals which resulted in the DSM Integration not being able to create sample code for users using HTML with Storybook 6.

We introduced a new `withDsmHtml` decorator which fixes this issue. Users on Storybook 6 should now use this new decorator instead of the old `withDsm` decorator.

