### PR TITLE
Fix SVG loading with latest Storybook webpack versions

### DIFF
--- a/react/storybook-v5/package.json
+++ b/react/storybook-v5/package.json
@@ -20,7 +20,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-scripts": "3.0.0",
-    "react-svg-inline": "2.1.1"
+    "react-svg": "^11.0.40"
   },
   "scripts": {
     "storybook": "start-storybook -p 9009 -s public",

--- a/react/storybook-v5/package.json
+++ b/react/storybook-v5/package.json
@@ -19,8 +19,7 @@
     "prop-types": "15.6.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "react-scripts": "3.0.0",
-    "react-svg": "^11.0.40"
+    "react-scripts": "3.0.0"
   },
   "scripts": {
     "storybook": "start-storybook -p 9009 -s public",

--- a/react/storybook-v5/src/components/Button.jsx
+++ b/react/storybook-v5/src/components/Button.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { chevronRightIcon } from './icons';
-import SVGInline from 'react-svg-inline';
+import { ChevronRightIcon } from './icons';
 
 import './_button.scss';
 
@@ -20,7 +19,7 @@ const Button = ({ onClick, icon, disabled, children }) => {
       <div className="c-button__content">{children}</div>
       {icon && (
         <div className="c-button__icon">
-          <SVGInline svg={chevronRightIcon} />
+          <ChevronRightIcon />
         </div>
       )}
     </button>

--- a/react/storybook-v5/src/components/Toast.jsx
+++ b/react/storybook-v5/src/components/Toast.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { CloseIcon } from './icons';
 import { toastIcons } from './icons/toast-icons';
-import { ReactSVG } from 'react-svg';
 
 import './_toast.scss';
 
@@ -10,9 +9,11 @@ import './_toast.scss';
  * Toasts provide dismissable feedback\information for the user.
  * */
 const Toast = ({ text, status }) => {
+  const ToastIcon = toastIcons[status];
+
   return (
     <div key={status} className={`c-toast ${status}`}>
-      <ReactSVG className={`c-toast__icon ${status}`} src={toastIcons[status]} />
+      <ToastIcon className={`c-toast__icon ${status}`} />
       <span className="c-toast__text">{text}</span>
       <CloseIcon className="c-toast__close-icon" />
     </div>

--- a/react/storybook-v5/src/components/Toast.jsx
+++ b/react/storybook-v5/src/components/Toast.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { closeIcon } from './icons';
+import { CloseIcon } from './icons';
 import { toastIcons } from './icons/toast-icons';
-import SVGInline from 'react-svg-inline';
+import { ReactSVG } from 'react-svg';
 
 import './_toast.scss';
 
@@ -12,9 +12,9 @@ import './_toast.scss';
 const Toast = ({ text, status }) => {
   return (
     <div key={status} className={`c-toast ${status}`}>
-      <SVGInline className={`c-toast__icon ${status}`} svg={toastIcons[status]} />
+      <ReactSVG className={`c-toast__icon ${status}`} src={toastIcons[status]} />
       <span className="c-toast__text">{text}</span>
-      <SVGInline className="c-toast__close-icon" svg={closeIcon} />
+      <CloseIcon className="c-toast__close-icon" />
     </div>
   );
 };

--- a/react/storybook-v5/src/components/icons/index.js
+++ b/react/storybook-v5/src/components/icons/index.js
@@ -1,9 +1,7 @@
-import flagIcon from './flag.svg';
-import warnIcon from './warn.svg';
-import checkmarkIcon from './check-circle.svg';
-import errorIcon from './close-circle.svg';
-import infoIcon from './info-circle.svg';
-import closeIcon from './close.svg';
-import chevronRightIcon from './chevron-right.svg';
-
-export { flagIcon, warnIcon, checkmarkIcon, errorIcon, infoIcon, closeIcon, chevronRightIcon };
+export { ReactComponent as FlagIcon } from './flag.svg';
+export { ReactComponent as WarnIcon } from './warn.svg';
+export { ReactComponent as CheckmarkIcon } from './check-circle.svg';
+export { ReactComponent as ErrorIcon } from './close-circle.svg';
+export { ReactComponent as InfoIcon } from './info-circle.svg';
+export { ReactComponent as CloseIcon } from './close.svg';
+export { ReactComponent as ChevronRightIcon } from './chevron-right.svg';

--- a/react/storybook-v5/src/components/icons/toast-icons.js
+++ b/react/storybook-v5/src/components/icons/toast-icons.js
@@ -1,11 +1,11 @@
-import { flagIcon, warnIcon, checkmarkIcon, errorIcon, infoIcon } from './index';
+import { FlagIcon, WarnIcon, CheckmarkIcon, ErrorIcon, InfoIcon } from './index';
 
 const toastIcons = {
-  default: flagIcon,
-  warning: warnIcon,
-  success: checkmarkIcon,
-  error: errorIcon,
-  info: infoIcon
+  default: FlagIcon,
+  warning: WarnIcon,
+  success: CheckmarkIcon,
+  error: ErrorIcon,
+  info: InfoIcon
 };
 
 export { toastIcons };

--- a/react/storybook-v6/package.json
+++ b/react/storybook-v6/package.json
@@ -17,8 +17,7 @@
     "prop-types": "15.6.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "react-scripts": "3.0.0",
-    "react-svg": "^11.0.40"
+    "react-scripts": "3.0.0"
   },
   "scripts": {
     "storybook": "start-storybook -p 9009 -s public",

--- a/react/storybook-v6/src/components/Button.jsx
+++ b/react/storybook-v6/src/components/Button.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { chevronRightIcon } from './icons';
-import { ReactSVG } from 'react-svg';
+import { ChevronRightIcon } from './icons';
 
 import './_button.scss';
 
@@ -20,7 +19,7 @@ const Button = ({ onClick, icon, disabled, children }) => {
       <div className="c-button__content">{children}</div>
       {icon && (
         <div className="c-button__icon">
-          <ReactSVG src={chevronRightIcon} />
+          <ChevronRightIcon />
         </div>
       )}
     </button>

--- a/react/storybook-v6/src/components/Toast.jsx
+++ b/react/storybook-v6/src/components/Toast.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { CloseIcon } from './icons';
 import { toastIcons } from './icons/toast-icons';
-import { ReactSVG } from 'react-svg';
 
 import './_toast.scss';
 
@@ -10,9 +9,11 @@ import './_toast.scss';
  * Toasts provide dismissable feedback\information for the user.
  * */
 const Toast = ({ text, status }) => {
+  const ToastIcon = toastIcons[status];
+
   return (
     <div key={status} className={`c-toast ${status}`}>
-      <ReactSVG className={`c-toast__icon ${status}`} src={toastIcons[status]} />
+      <ToastIcon className={`c-toast__icon ${status}`} />
       <span className="c-toast__text">{text}</span>
       <CloseIcon className="c-toast__close-icon" />
     </div>

--- a/react/storybook-v6/src/components/Toast.jsx
+++ b/react/storybook-v6/src/components/Toast.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ReactComponent as CloseIcon } from './icons/close.svg';
+import { CloseIcon } from './icons';
 import { toastIcons } from './icons/toast-icons';
 import { ReactSVG } from 'react-svg';
 

--- a/react/storybook-v6/src/components/icons/index.js
+++ b/react/storybook-v6/src/components/icons/index.js
@@ -1,9 +1,7 @@
-import flagIcon from './flag.svg';
-import warnIcon from './warn.svg';
-import checkmarkIcon from './check-circle.svg';
-import errorIcon from './close-circle.svg';
-import infoIcon from './info-circle.svg';
-import closeIcon from './close.svg';
-import chevronRightIcon from './chevron-right.svg';
-
-export { flagIcon, warnIcon, checkmarkIcon, errorIcon, infoIcon, closeIcon, chevronRightIcon };
+export { ReactComponent as FlagIcon } from './flag.svg';
+export { ReactComponent as WarnIcon } from './warn.svg';
+export { ReactComponent as CheckmarkIcon } from './check-circle.svg';
+export { ReactComponent as ErrorIcon } from './close-circle.svg';
+export { ReactComponent as InfoIcon } from './info-circle.svg';
+export { ReactComponent as CloseIcon } from './close.svg';
+export { ReactComponent as ChevronRightIcon } from './chevron-right.svg';

--- a/react/storybook-v6/src/components/icons/toast-icons.js
+++ b/react/storybook-v6/src/components/icons/toast-icons.js
@@ -1,11 +1,11 @@
-import { flagIcon, warnIcon, checkmarkIcon, errorIcon, infoIcon } from './index';
+import { FlagIcon, WarnIcon, CheckmarkIcon, ErrorIcon, InfoIcon } from './index';
 
 const toastIcons = {
-  default: flagIcon,
-  warning: warnIcon,
-  success: checkmarkIcon,
-  error: errorIcon,
-  info: infoIcon
+  default: FlagIcon,
+  warning: WarnIcon,
+  success: CheckmarkIcon,
+  error: ErrorIcon,
+  info: InfoIcon
 };
 
 export { toastIcons };


### PR DESCRIPTION
## Description
Some examples incorrectly displayed the webpack static assets path instead of rendering an SVG.

## Referenced issues
