### PR TITLE
Migrate Storybook 6 Angular Button Example to Args

### DIFF
--- a/angular/storybook-v6/package.json
+++ b/angular/storybook-v6/package.json
@@ -36,17 +36,17 @@
     "@angular/compiler-cli": "~8.0.0",
     "@angular/language-service": "~8.0.0",
     "@babel/core": "^7.4.5",
-    "@storybook/addon-actions": "^6.0.0",
-    "@storybook/addon-knobs": "^6.0.0",
-    "@storybook/addon-essentials": "^6.0.0",
+    "@storybook/addon-a11y": "6.0.0",
+    "@storybook/addon-actions": "6.0.0",
+    "@storybook/addon-docs": "6.0.0",
+    "@storybook/addon-essentials": "6.0.0",
+    "@storybook/addon-knobs": "6.0.0",
     "@storybook/addon-options": "5.3.21",
-    "@storybook/addon-a11y": "^6.0.0",
-    "@storybook/addon-docs": "^6.0.0",
-    "@storybook/addons": "^6.0.0",
-    "@storybook/angular": "^6.0.0",
+    "@storybook/addons": "6.0.0",
+    "@storybook/angular": "6.0.0",
     "@types/jasmine": "~3.3.8",
     "@types/jasminewd2": "~2.0.3",
-    "@types/node": "~8.9.4",
+    "@types/node": "^8.9.5",
     "babel-loader": "^8.0.6",
     "codelyzer": "^5.0.0",
     "jasmine-core": "~3.4.0",
@@ -60,6 +60,6 @@
     "svg-inline-loader": "^0.8.0",
     "ts-node": "~7.0.0",
     "tslint": "~5.15.0",
-    "typescript": "~3.4.3"
+    "typescript": "^4.0.0"
   }
 }

--- a/angular/storybook-v6/src/stories/button.stories.ts
+++ b/angular/storybook-v6/src/stories/button.stories.ts
@@ -1,6 +1,4 @@
 import { moduleMetadata } from '@storybook/angular';
-import { withKnobs, text, select, boolean } from '@storybook/addon-knobs';
-import { action } from '@storybook/addon-actions';
 import { ButtonComponent } from '../app/components/button/button.component';
 import { AppIconComponent } from '../app/components/icons/app-icon.component';
 import { HttpClientModule } from '@angular/common/http';
@@ -12,14 +10,13 @@ import buttonDocs from './button.mdx';
 // https://storybook.js.org/docs/formats/component-story-format/
 export default {
   title: 'Button',
+  decorators: [
+    moduleMetadata({
+      declarations: [ButtonComponent, AppIconComponent],
+      imports: [HttpClientModule, AngularSvgIconModule]
+    })
+  ],
   parameters: {
-    decorators: [
-      withKnobs,
-      moduleMetadata({
-        declarations: [ButtonComponent, AppIconComponent],
-        imports: [HttpClientModule, AngularSvgIconModule]
-      })
-    ],
     // Module-Level 'in-dsm' configuration (Will apply to all stories inside the module)
     'in-dsm': {
       id: '5c86295038392c00aafece83',
@@ -29,16 +26,18 @@ export default {
   }
 };
 
-export const simpleButton = () => ({
-  template:
-    '<button dsm-button (didClick)="actionProp()" [text]="textKnob" [icon]="iconKnob" [disabled]="disabledKnob"></button>',
+export const simpleButton = (args) => ({
+  component: ButtonComponent,
   props: {
-    textKnob: text('text', 'TEXT'),
-    iconKnob: select('icon', ['none', 'chevron-right'], 'none'),
-    disabledKnob: boolean('disabled', false),
-    actionProp: () => action('Button clicked')('Click')
+    ...args
   }
 });
+
+simpleButton.args = {
+  text: 'Text',
+  disabled: false,
+  icon: 'none'
+};
 
 simpleButton.story = {
   parameters: {


### PR DESCRIPTION
## Description
We're changing some of the examples to use Storybook's args feature. This also fixes a template parsing issue that occurs with the knobs format.

